### PR TITLE
corrects build command to include full 'npm run compile'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ cf push myapp
 ```
 # Try it!
 
-- Interactive API doc at [http://localhost:3000/api-explorer](http://localhost:3000/api)
-- Static resources at [http://localhost:3000/api-explorer](http://localhost:3000/api)
+- Interactive API doc at [http://localhost:3000/api-explorer](http://localhost:3000/api-explorer)
+- Static resources at [http://localhost:3000/api-explorer](http://localhost:3000/api-explorer)
 
 ## Use Yarn
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run dev
 #### Run in *production* mode:
 
 ```
-npm compile
+npm run compile
 npm start
 ```
 


### PR DESCRIPTION
simple update to README.  

The `npm compile` command will fail, since npm expects `npm run compile`.

Also updates the try-it-out links.