### PR TITLE
Update ESLint ignore files

### DIFF
--- a/app/templates/.eslintignore
+++ b/app/templates/.eslintignore
@@ -1,2 +1,5 @@
+node_modules/
+dist/
+public/api-explorer/
 *.yaml
 *.yml

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -10,8 +10,8 @@
     "dev:debug": "nodemon server --exec babel-node --config .nodemonrc.json --inspect | pino-pretty",
     "test": "mocha --require @babel/register --exit",
     "test:debug": "mocha --require @babel/register --inspect-brk --exit",
-    "lint": "eslint -c .eslintrc.json {server,test}/**",
-    "lint:fix": "eslint --fix -c .eslintrc.json {server,test}/**"
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix ."
   },
   "dependencies": {
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Ignore `node_modules` directory
Ignore compiled files
Ignore third party directory
Due the update of `.eslintignore` is not necessary to be explicit with targets