### PR TITLE
fix: remove duplicate parserOptions at .eslintrc.json

### DIFF
--- a/app/templates/.eslintrc.json
+++ b/app/templates/.eslintrc.json
@@ -8,9 +8,6 @@
   "env": {
     "mocha": true
   },
-  "parserOptions": {
-    "sourceType": "module"
-  },
   "rules": {
     "no-underscore-dangle": 0,
     "class-methods-use-this": ["off"],


### PR DESCRIPTION
Hi @cdimascio , thank you for develop this generator :) .
i found duplicate key `parserOptions` when choose Airbnb Linter.

<img width="447" alt="Screen Shot 2022-07-19 at 21 50 50" src="https://user-images.githubusercontent.com/25176229/179780544-e0f45472-63b6-4afb-96b0-c42b9aa00b83.png">

